### PR TITLE
Split deserialize and cast

### DIFF
--- a/lib/ulid/rails/type.rb
+++ b/lib/ulid/rails/type.rb
@@ -1,5 +1,6 @@
 require "active_model/type"
 require "ulid/rails/formatter"
+require "ulid/rails/validator"
 
 module ULID
   module Rails
@@ -8,9 +9,14 @@ module ULID
         alias_method :hex, :to_s
       end
 
-      def initialize(formatter = Formatter)
+      def initialize(formatter = Formatter, validator = Validator)
         @formatter = formatter
+        @validator = validator
         super()
+      end
+
+      def assert_valid_value(value)
+        raise ArgumentError, "`#{value}` is not a ULID format" unless @validator.is_valid?(value)
       end
 
       def deserialize(value)

--- a/lib/ulid/rails/type.rb
+++ b/lib/ulid/rails/type.rb
@@ -13,7 +13,7 @@ module ULID
         super()
       end
 
-      def cast(value)
+      def deserialize(value)
         return nil if value.nil?
 
         value = value.to_s if value.is_a?(Data)

--- a/lib/ulid/rails/validator.rb
+++ b/lib/ulid/rails/validator.rb
@@ -1,0 +1,11 @@
+require "base32/crockford"
+
+module ULID
+  module Rails
+    module Validator
+      def self.is_valid?(v)
+        v.length == 26 && Base32::Crockford.valid?(v)
+      end
+    end
+  end
+end

--- a/test/ulid/rails_test.rb
+++ b/test/ulid/rails_test.rb
@@ -27,6 +27,23 @@ class ULID::RailsTest < Minitest::Test
     assert widget.ulid
   end
 
+  def test_manual_id_generation
+    ulid_id = ULID.generate
+    user = User.new(id: ulid_id)
+
+    # here testing that cast is not messing with the setter
+    assert user.id == ulid_id
+
+    user.save
+    assert user.id == ulid_id
+  end
+
+  def test_validate_ulid_format
+    non_ulid_id = "I am not a ulid"
+
+    assert_raises(ArgumentError) { User.new(id: non_ulid_id) }
+  end
+
   def test_has_many_through
     # Doesn't work until https://github.com/rails/rails/issues/35839 is released
 #    user = User.create!


### PR DESCRIPTION
This fixes compatibility with latest version of [Ruby ULID](https://github.com/rafaelsales/ulid). Therefore we gain the millisecond precision for ulids.

The problem was introduced between Ruby ULID v1.1.1 and v1.2.0. The generated ULID changed encoding from utf8 to ascii-8bit.

In this PR, I split `deserialize` and `cast`. All the logic that was implemented as cast, is needed only for the deserialization of the binary data from db. Documentation about `cast` and `deserialize` [here](https://api.rubyonrails.org/classes/ActiveModel/Type/Value.html#method-i-cast_value).

`assert_valid_value` method is used to validate ULID format compatibility.